### PR TITLE
Add shop_images directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /app/Config/database.php
 /app/Vendor/*
 /app/ShopAreaWiki_webroot/img/shop_images/*
+!.gitkeep


### PR DESCRIPTION
出力先となるshop_imagesのフォルダを追加
空ディレクトリのまま管理するため.gitignoreに追記
