### PR TITLE
Add Validation for New Shop Data

### DIFF
--- a/app/Model/Shop.php
+++ b/app/Model/Shop.php
@@ -2,5 +2,32 @@
 class Shop extends AppModel {
 	public $hasMany = 'Floor';
 
+	//バリデーション
+	public $validate = array(
+		//ショップ名
+		'name' => array(
+    			'notEmpty' => array(
+      				'rule'    => 'notEmpty',
+      				'allowEmpty' => true,
+    			)
+ 	 	),
+
+ 	 	//郵便番号
+ 	 	'postal_code' => array(
+    			'notEmpty' => array(
+      				'rule' => array( 'custom', '/^[0-9]{3}-[0-9]{4}$/'),//ハイフン必須
+      				//'rule' => array( 'custom', '/^[0-9]{3}[\s-]?[0-9]{4}$/'),//ハイフンあってもなくてもOK
+      				'allowEmpty' => true,
+    			)
+ 	 	),
+
+ 	 	//住所
+ 	 	'street_address' => array(
+    			'notEmpty' => array(
+      				'rule'    => 'notEmpty',
+      				'allowEmpty' => false,
+    			)
+ 	 	),
+	);
 }
 ?>

--- a/app/View/Shops/add.ctp
+++ b/app/View/Shops/add.ctp
@@ -44,12 +44,12 @@
 
 			<!-- 店名 -->
 			<div class="row">
-				<div class="col-md-4"><input class="form-control" placeholder="店名" name="data[Shop][name]" maxlength="60" type="text" id="ShopName"/></div>
+				<div class="col-md-4"><input class="form-control" placeholder="店名 (必須)" name="data[Shop][name]" maxlength="60" type="text" id="ShopName" required aria-required="true"/></div>
 			</div>
 
 			<!-- 郵便番号 -->
 			<div class="row">
-				<div class="col-md-4"><input class="form-control" placeholder="郵便番号" name="data[Shop][postal_code]" maxlength="10" type="text" id="ShopPostalCode"/></div>
+				<div class="col-md-4"><input class="form-control" placeholder="郵便番号 [入力例:123-4567]" name="data[Shop][postal_code]" maxlength="10" type="text" id="ShopPostalCode"/></div>
 			</div>
 
 			<div class="row"><div class="col-md-12">
@@ -109,7 +109,7 @@
 
 			<!-- 住所 -->
 			<div class="row">
-				<div class="col-md-4"><input class="form-control" placeholder="住所" name="data[Shop][street_address]" maxlength="100" type="text" id="ShopStreetAddress"/></div>
+				<div class="col-md-4"><input class="form-control" placeholder="住所 (必須)" name="data[Shop][street_address]" maxlength="100" type="text" id="ShopStreetAddress" required aria-required="true"/></div>
 			</div>
 
 			<!-- カテゴリー -->


### PR DESCRIPTION
店舗情報新規登録時のバリデーションを追加し、ビューのフォーム内にも明記しました。
入力にミスがある場合save shopボタンを押しても登録、画面移動しないようにしています。

・店舗名…入力必須
・郵便番号…空か”123-4567”形式での入力のみ受け取る
・住所…入力必須

(住所は入力しないと緯度経度登録時にエラー出て進まなくなるのでとりあえずの処理です。細かい制約をつけるか、空入力できるようにするかなどまだ考案中です。)

11/20(金)までに何も出なければマージします。
