### PR TITLE
improve map search (Clustering of marker)

### DIFF
--- a/app/View/Shops/index.ctp
+++ b/app/View/Shops/index.ctp
@@ -4,6 +4,8 @@
 <!-- グーグルヘルパー読み込み -->
 <!-- <?= $this->Html->script('http://maps.google.com/maps/api/js?sensor=true', false); ?>  -->
 <?= $this->Html->script('http://maps.google.com/maps/api/js?sensor=false', true); ?>
+<!-- マーカーをクラスタ化するために必要 -->
+<?= $this->Html->script("http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js", true); ?>
 <!-- 始_グーグルマップオプション -->
 
 <?php
@@ -113,6 +115,8 @@ $map_options = array(
 			<!-- マーカー付け -->
 			<?= $this->GoogleMap->addMarker("map_canvas", $shop_marker_num, array('latitude' => $shop['Shop']['latitude'], 'longitude' => $shop['Shop']['longitude']), $marker_options); ?>
 		<?php endforeach; ?>
+		<!-- マーカーのクラスタ化（近いものはまとめて表示） -->
+		<?php echo $this->GoogleMap->clusterMarkers("map_canvas");?>
 
 		<!-- 使わないけど残しておく範囲 -->
 		<?php


### PR DESCRIPTION
負荷を減らすために，縮小した際，近いマーカーをまとめて表示するようにしました．
この機能の付加価値として，ちゃっかり利便性も上がってます．

機能のテストは，
・近場にたくさん店を作る（近い地点のマーカーを増やす）
・トップページの地図を縮小する
で行えます．

負荷の減らし方として，「マップの表示範囲内のみのマーカーを表示する」という方法もありますが，
２週間やって上手くいかなかった＆さらに良い方法（本機能）を見つけたのでこっちにしました．

期限は２７日（金）です．
味岡さんがマージしたらこちらもマージする予定です．
